### PR TITLE
ui: add tooltip for control map

### DIFF
--- a/scenes/office/office.tscn
+++ b/scenes/office/office.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=38 format=3 uid="uid://bd72q7axcpr7m"]
+[gd_scene load_steps=40 format=3 uid="uid://bd72q7axcpr7m"]
 
 [ext_resource type="PackedScene" uid="uid://tk0n1i5iben6" path="res://ui/hud/hud.tscn" id="1_ql6sr"]
 [ext_resource type="Texture2D" uid="uid://wa6vbqiokghf" path="res://textures/floor_texture.jpg" id="2_llti7"]
@@ -15,6 +15,8 @@
 [ext_resource type="PackedScene" uid="uid://brmo4pl84byk8" path="res://utilities/dialogue_holder/dialogue_holder.tscn" id="13_y3s53"]
 [ext_resource type="Script" uid="uid://rrt2j7s4yj5a" path="res://resources/dialogue/save_path_dialogue_line/save_path_dialogue_line.gd" id="14_p8n5g"]
 [ext_resource type="Script" uid="uid://1el3k4k7hwkc" path="res://scenes/office/callback.gd" id="15_yexkw"]
+[ext_resource type="Script" uid="uid://bit54ai80bgem" path="res://scenes/office/tooltip.gd" id="16_qei30"]
+[ext_resource type="FontFile" uid="uid://l1pv5jrv71g0" path="res://ui/dialogue/EXT_VCR_OSD_MONO.ttf" id="16_vyb6o"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_art4y"]
 albedo_texture = ExtResource("5_66du1")
@@ -349,6 +351,14 @@ dialogue = Array[ExtResource("14_p8n5g")]([SubResource("Resource_yexkw"), SubRes
 
 [node name="Callback" type="Node" parent="WinTrigger/WinDialogue"]
 script = ExtResource("15_yexkw")
+
+[node name="Tooltip" type="Label3D" parent="."]
+transform = Transform3D(-4.371139e-08, 0, 1, 0, 1, 0, -1, 0, -4.371139e-08, 24.846104, 2, 7.6148977)
+billboard = 1
+double_sided = false
+text = "Sample text"
+font = ExtResource("16_vyb6o")
+script = ExtResource("16_qei30")
 
 [connection signal="presence_declared" from="Player" to="Boss" method="_on_player_presence_declared"]
 [connection signal="body_entered" from="Detection Area" to="Detection Area" method="_on_body_entered"]

--- a/scenes/office/tooltip.gd
+++ b/scenes/office/tooltip.gd
@@ -1,0 +1,17 @@
+extends Label3D
+
+func _get_action_key(action: String) -> String:
+	return InputMap.action_get_events(action).front().as_text()
+
+func _ready() -> void:
+	if SaveCookieController.retrieve_savepoint() == SaveCookieController.SavePoint.RUN1:
+		text = "Use "
+		text += _get_action_key(&"move_forwards").substr(0, 1) + " "
+		text += _get_action_key(&"move_left").substr(0, 1) + " "
+		text += _get_action_key(&"move_backwards").substr(0, 1) + " "
+		text += _get_action_key(&"move_right").substr(0, 1)
+		text += " for movement"
+		text += "\n\n"
+		text += _get_action_key(&"shoot") + " to shoot"
+	else:
+		text = ""

--- a/scenes/office/tooltip.gd.uid
+++ b/scenes/office/tooltip.gd.uid
@@ -1,0 +1,1 @@
+uid://bit54ai80bgem


### PR DESCRIPTION
Add a tooltip as a 3D label in the scene to inform the player about the controls.

- The tooltip only appears on the first run.
- The tooltip looks like this: 
<img width="1147" height="641" alt="image" src="https://github.com/user-attachments/assets/b074ef76-d942-4e70-8e43-01a36a811c65" />
